### PR TITLE
feat: add endpoint to handle GitHub sponsors webhooks

### DIFF
--- a/api_webhookGithubSponsors/function.json
+++ b/api_webhookGithubSponsors/function.json
@@ -1,0 +1,21 @@
+{
+    "bindings": [
+      {
+        "type": "httpTrigger",
+        "direction": "in",
+        "name": "req",
+        "authLevel": "anonymous",
+        "methods": [
+          "get",
+          "post",
+          "options"
+        ],
+        "route": "status"
+      },
+      {
+        "type": "http",
+        "direction": "out",
+        "name": "res"
+      }
+    ]
+  }

--- a/api_webhookGithubSponsors/index.js
+++ b/api_webhookGithubSponsors/index.js
@@ -1,0 +1,133 @@
+'use strict'
+
+const Archetype = require('archetype');
+const azureWrapper = require('../util/azureWrapper');
+const connect = require('../src/db');
+
+const GithubEntity = new Archetype({
+  login: {
+    $type: 'string',
+    $required: true
+  },
+  id: {
+    $type: 'number',
+    $required: true
+  },
+  type: {
+    $type: 'string'
+  }
+}).compile('GithubEntity');
+
+const GithubSponsorsParams = new Archetype({
+  action: {
+    $type: 'string',
+    $required: true
+  },
+  sponsorship: {
+    sponsor: {
+      $type: GithubEntity,
+      $required: true
+    },
+    tier: {
+      name: {
+        $type: 'string',
+        $required: true
+      },
+      is_one_time: {
+        $type: 'boolean'
+      },
+      is_custom_amount: {
+        $type: 'boolean'
+      }
+    }
+  },
+  sender: {
+    $type: GithubEntity,
+    $required: true
+  }
+}).compile('GithubSponsorsParams');
+
+module.exports = azureWrapper(webhookGithubSponsors);
+module.exports.rawFunction = webhookGithubSponsors;
+
+async function webhookGithubSponsors(context, req) {
+  const conn = await connect();
+  const AccessToken = conn.model('AccessToken');
+  const Subscriber = conn.model('Subscriber');
+  const Task = conn.model('Task');
+
+  const task = await Task.create({
+    method: req.method,
+    url: req.url,
+    params: req.body
+  });
+
+  const { action, sponsorship, sender } = new GithubSponsorsParams(req.body);
+
+  let subscriber;
+  switch (action) {
+    case 'created':
+      if (sponsorship.tier.name !== 'Mongoose Pro Subscriber') {
+        break;
+      }
+      if (sponsorship.tier.is_one_time) {
+        break;
+      }
+      if (sponsorship.tier.is_custom_amount) {
+        break;
+      }
+
+      const data = {
+        githubUsername: sender.login,
+        githubUserId: sender.id
+      };
+      if (sponsorship.sponsor.type === 'Organization') {
+        Object.assign(data, {
+          githubOrganization: sponsorship.sponsor.login,
+          githubOrganizationId: sponsorship.sponsor.id
+        });
+      }
+
+      subscriber = await Subscriber.create(data);
+  
+      return { subscriber };
+    case 'tier_changed':
+      if (sponsorship.tier.name !== 'Mongoose Pro Subscriber') {
+        subscriber = await Subscriber.findOneAndUpdate({ githubOrganizationId: sponsorship.sponsor.id }, {
+          $set: {
+            status: 'disabled'
+          }
+        }, { returnOriginal: false });
+  
+        if (subscriber == null) {
+          break;
+        }
+    
+        return { subscriber };
+      }
+
+      subscriber = await Subscriber.findOneAndUpdate({ githubOrganizationId: sponsorship.sponsor.id }, {
+        githubUsername: sender.login,
+        githubUserId: sender.id,
+        githubOrganization: sponsorship.sponsor.login
+      }, { returnOriginal: false, upsert: true });
+  
+      return { subscriber };
+    case 'cancelled':
+      subscriber = await Subscriber.findOneAndUpdate({ githubOrganizationId: sponsorship.sponsor.id }, {
+        $set: {
+          status: 'disabled'
+        }
+      }, { returnOriginal: false });
+
+      if (subscriber == null) {
+        break;
+      }
+  
+      return { subscriber };
+    default:
+      break;
+  }
+
+  return { $ignored: true };
+};

--- a/src/db/subscriber.js
+++ b/src/db/subscriber.js
@@ -3,7 +3,12 @@
 const mongoose = require('mongoose');
 
 const subscriberSchema = new mongoose.Schema({
-  email: { type: String, required: true },
+  status: {
+    type: String,
+    enum: ['enabled', 'disabled'],
+    default: 'enabled'
+  },
+  email: { type: String },
   githubUsername: { type: String, required: true },
   githubUserId: { type: String },
   githubOrganization: { type: String },

--- a/test/webhookGithubSponsors.test.js
+++ b/test/webhookGithubSponsors.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const assert = require('assert');
+const connect = require('../src/db');
+const api_webhookGithubSponsors = require('../api_webhookGithubSponsors').rawFunction;
+
+describe('webhookGithubSponsors', function() {
+  it('creates a new subscriber doc when a new organization subscribes', async function() {
+    const { subscriber } = await api_webhookGithubSponsors(null, {
+      body: {
+        "action": "created",
+        "sponsorship": {
+          "sponsor": {
+            "login": "org",
+            "id": 2,
+            "type": "Organization"
+          },
+          "privacy_level": "public",
+          "tier": {
+            "name": "Mongoose Pro Subscriber",
+            "is_one_time": false,
+            "is_custom_amount": false
+          }
+        },
+        "sender": {
+          "login": "user",
+          "id": 3
+        }
+      }
+    });
+
+    const conn = await connect();
+    const Subscriber = conn.model('Subscriber');
+    const fromDb = await Subscriber.findById(subscriber);
+    assert.equal(fromDb.githubUserId, 3);
+    assert.equal(fromDb.githubUsername, 'user');
+    assert.equal(fromDb.githubOrganization, 'org');
+    assert.equal(fromDb.githubOrganizationId, 2);
+  });
+
+  it('creates a new subscriber doc when a new user subscribes', async function() {
+    const { subscriber } = await api_webhookGithubSponsors(null, {
+      body: {
+        "action": "created",
+        "sponsorship": {
+          "sponsor": {
+            "login": "user2",
+            "id": 2,
+            "type": "User"
+          },
+          "privacy_level": "public",
+          "tier": {
+            "name": "Mongoose Pro Subscriber",
+            "is_one_time": false,
+            "is_custom_amount": false
+          }
+        },
+        "sender": {
+          "login": "user",
+          "id": 3
+        }
+      }
+    });
+
+    const conn = await connect();
+    const Subscriber = conn.model('Subscriber');
+    const fromDb = await Subscriber.findById(subscriber);
+    assert.equal(fromDb.githubUserId, 3);
+    assert.equal(fromDb.githubUsername, 'user');
+    assert.ok(!fromDb.githubOrganization);
+    assert.ok(!fromDb.githubOrganizationId);
+  });
+});


### PR DESCRIPTION
Docs from here: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#sponsorship

GitHub sends us a webhook whenever a sponsor subscribes, cancels, or changes their subscription. This endpoint should be enough to keep the subscriber doc in sync.