### PR TITLE
Fix verifyGithubAccessToken populate

### DIFF
--- a/src/actions/verifyGithubAccessToken.js
+++ b/src/actions/verifyGithubAccessToken.js
@@ -14,7 +14,7 @@ module.exports = ({ task, conn }) => async function verifyGithubAccessToken(para
   const { authorization } = new VerifyGithubAccessTokenParams(params);
   
   const token = await task.sideEffect(function exists({ _id }) {
-    return AccessToken.findOne({ _id }).populate('subscriberId');
+    return AccessToken.findOne({ _id }).populate('userId');
   }, { _id: authorization });
 
   return { exists: !!token, token };

--- a/test/verifyGithubAccessToken.test.js
+++ b/test/verifyGithubAccessToken.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const assert = require('assert');
+const connect = require('../src/db');
+const verifyGithubAccessTokenFactory = require('../src/actions/verifyGithubAccessToken');
+const { beforeEach, describe, it } = require('mocha');
+
+describe('verifyGithubAccessToken', function() {
+  let db, User, AccessToken, verifyGithubAccessToken, user, accessToken;
+
+  beforeEach(async function() {
+    db = await connect();
+    ({ User, AccessToken } = db.models);
+    await User.deleteMany({});
+    await AccessToken.deleteMany({});
+
+    user = await User.create({ email: 'test@example.com', githubUsername: 'test' });
+    accessToken = await AccessToken.create({ userId: user._id });
+
+    const task = { sideEffect: async (fn, params) => fn(params) };
+    verifyGithubAccessToken = verifyGithubAccessTokenFactory({ task, conn: db });
+  });
+
+  it('populates userId when token exists', async function() {
+    const res = await verifyGithubAccessToken({ authorization: accessToken._id });
+    assert.strictEqual(res.exists, true);
+    assert.ok(res.token.userId.githubUsername);
+    assert.strictEqual(res.token.userId.githubUsername, 'test');
+  });
+});


### PR DESCRIPTION
## Summary
- fix field name in verifyGithubAccessToken
- add tests for verifying github access tokens

## Testing
- `npm test` *(fails: env: ‘mocha’: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68557048b3b48324b85330cec07d45b2