### PR TITLE
Fix schema name in removeFromWorkspace

### DIFF
--- a/src/actions/removeFromWorkspace.js
+++ b/src/actions/removeFromWorkspace.js
@@ -18,7 +18,7 @@ const RemoveFromWorkspaceParams = new Archetype({
     $type: mongoose.Types.ObjectId,
     $required: true
   }
-}).compile('InviteToWorkspaceParams');
+}).compile('RemoveFromWorkspaceParams');
 
 module.exports = async function removeFromWorkspace(params) {
   const db = await connect();


### PR DESCRIPTION
## Summary
- fix schema name for removing users from a workspace

## Testing
- `npm test` *(fails: `env: ‘mocha’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_685580a9d308832496ce483485af7ece