### PR TITLE
Fix toLowerCase call in channel creation

### DIFF
--- a/createChannel.js
+++ b/createChannel.js
@@ -22,7 +22,7 @@ async function run() {
     }
     r1.question('public or private? ', async function(status) {
       console.log('status', status, typeof status, status.toLowerCase());
-      if (status.toLowerCase == 'public') {
+      if (status.toLowerCase() == 'public') {
         status = false;
       } else if (status.toLowerCase() == 'private') {
         status = true;


### PR DESCRIPTION
## Summary
- fix wrong `toLowerCase` usage when checking channel type

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855837f6e008324b221d5e25d304e00